### PR TITLE
Align calendar and book panels and adjust sizing

### DIFF
--- a/parsklands.html
+++ b/parsklands.html
@@ -45,33 +45,38 @@
     margin:0 auto 18px;        /* centers the whole block */
     display:flex;
     justify-content:center;    /* centers the pair inside */
-    align-items:flex-start;
+    align-items:center;
     gap:24px;
   }
   .home-grid > *{ min-width:0; }
 
   .calendar-wrap{
-    flex:0 1 clamp(400px,38vw,540px);
+    flex:0 1 clamp(460px,42vw,620px);
     background:rgba(255,255,255,0.92);
     padding:12px;
     border:4px groove #222;
     box-shadow:4px 4px 8px #555;
     font-family:'Baskervville',serif;
     overflow:hidden;
+    display:flex;
+    align-self:center;
   }
 
   .calendar-embed{
     width:100%;
-    height:720px;
+    height:100%;
+    min-height:620px;
     border:0;
     display:block;
+    flex:1;
   }
 
   /* ======== BOOK ======== */
   .book-shell{
-    flex:1 1 720px;
-    min-width:560px;
+    flex:0 1 clamp(540px,50vw,740px);
+    min-width:520px;
     display:flex;
+    align-items:center;
   }
 
   .book-scale-wrap{
@@ -87,7 +92,7 @@
     border:4px groove #222;
     box-shadow:4px 4px 8px #555;
     width:100%;
-    max-width:100%;
+    max-width:94%;
     margin:0;
     font-family:'Baskervville',serif;
     overflow:hidden;
@@ -168,6 +173,7 @@
   @media (max-width:900px){
     .home-grid{ flex-direction:column; align-items:stretch; gap:12px; }
     .book-shell{ min-width:0; }
+    .spread{ max-width:100%; }
     .calendar-embed{ height:620px; }
   }
 
@@ -267,6 +273,26 @@
     .then(r => r.text())
     .then(html => { document.getElementById("footer").innerHTML = html; })
     .catch(err => console.error("Footer failed to load.", err));
+
+  // Keep calendar panel visually matched to the book panel height.
+  const bookSpread = document.getElementById("bookSpread");
+  const calendarWrap = document.querySelector(".calendar-wrap");
+
+  function syncCalendarHeight(){
+    if (!bookSpread || !calendarWrap || window.innerWidth <= 900) {
+      if (calendarWrap) calendarWrap.style.height = "";
+      return;
+    }
+    const h = Math.ceil(bookSpread.getBoundingClientRect().height);
+    if (h > 0) calendarWrap.style.height = `${h}px`;
+  }
+
+  window.addEventListener("load", syncCalendarHeight);
+  window.addEventListener("resize", syncCalendarHeight);
+
+  if (window.ResizeObserver && bookSpread) {
+    new ResizeObserver(syncCalendarHeight).observe(bookSpread);
+  }
 
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Fix calendar day tiles spilling out of their boxes by ensuring the calendar panel matches the book panel height and both sections are vertically centered. 
- Give the calendar slightly more room and make the book a bit smaller so both panels balance visually. 

### Description
- Changed two-column container alignment to center the pair using `.home-grid { align-items: center; }` so the calendar and book stay vertically aligned. 
- Adjusted sizing of columns by updating `.calendar-wrap` to `flex:0 1 clamp(460px,42vw,620px)` and `.book-shell` to `flex:0 1 clamp(540px,50vw,740px)` and reduced `.spread` `max-width` to `94%` to make the book a tad smaller. 
- Made the calendar iframe fill its container with `.calendar-embed { height:100%; min-height:620px; flex:1; }` and ensured `.calendar-wrap` uses `display:flex` for proper sizing. 
- Added a `syncCalendarHeight()` routine that sets the calendar panel height to match the rendered `#bookSpread` on desktop, wired to `load`, `resize`, and a `ResizeObserver`, and cleared the forced height at `<=900px` to preserve mobile behavior. 

### Testing
- Served the site locally with `python3 -m http.server 4173` and inspected `http://127.0.0.1:4173/parsklands.html` to validate layout changes. 
- Ran a Playwright script that loaded the page at 1600×1200 and captured a full-page screenshot to verify the calendar and book panels are centered and height-matched. 
- No automated test failures were observed during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3af90087c83248d0fbd08ce1e5a28)