### PR TITLE
Improve calendar layout/responsiveness and sync calendar height with book spread

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -10,6 +10,7 @@
 
     <div class="owcal-top-right">
       <button class="owcal-btn" id="jumpToday" type="button">Jump to Today</button>
+    </div>
   </div>
 
   <!-- MONTH SCROLLER (12 “pages”) -->
@@ -19,7 +20,16 @@
 </div>
 
 <style>
-.owcal { font-family: inherit; color: inherit; }
+.owcal {
+  font-family: inherit;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1.2;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
 
 .owcal .owcal-topbar{
   background-color: rgba(255,255,255,0.85);
@@ -81,6 +91,9 @@
   border: 4px groove #222;
   box-shadow: 4px 4px 8px #555;
   padding: 14px;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* Horizontal month scroller */
@@ -94,6 +107,7 @@
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
   align-items: stretch;       /* makes spacer match month height */
+  height: 100%;
 }
 
 /* Special single-day page (start / between seasons / end) */
@@ -109,8 +123,7 @@
 }
 
 .owcal .owcal-specialHead{
-  background-image: url("https://blob.gifcities.org/gifcities/BXSEWKELIKS4QP5GD7IBTDUHN22ZPTTI.gif");
-  background-repeat: repeat;
+  background: linear-gradient(180deg, #3d2d4f 0%, #2a1f36 100%);
   border-bottom: 3px double #000;
   padding: 14px 12px;
   display:flex;
@@ -140,11 +153,13 @@
   border: 4px ridge #333;
   box-shadow: 6px 6px 10px #444;
   background: rgba(255,255,255,0.88);
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  min-height: 0;
 }
 
 .owcal .owcal-monthHead{
-  background-image: url("https://blob.gifcities.org/gifcities/BXSEWKELIKS4QP5GD7IBTDUHN22ZPTTI.gif");
-  background-repeat: repeat;
+  background: linear-gradient(180deg, #3d2d4f 0%, #2a1f36 100%);
   border-bottom: 3px double #000;
   padding: 14px 12px;
   display:flex;
@@ -165,10 +180,10 @@
 
 .owcal .owcal-weekNames{
   display:grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 8px;
   padding: 12px;
-  font-size: 0.85em;
+  font-size: clamp(0.76rem, 0.75vw, 0.88rem);
 }
 .owcal .owcal-weekNames div{
   display:flex;
@@ -180,16 +195,21 @@
   background: #fffbe0;
   padding: 6px 7px;
   font-family: inherit;   /* follow site stylesheet */
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.1;
 }
 
 /* Day grid: 6 columns (weeks) x 5 rows (weekdays)
    This makes weekdays run TOP→BOTTOM, weeks run LEFT→RIGHT */
 .owcal .owcal-grid{
   display:grid;
-  grid-template-columns: repeat(6, 1fr);
-  grid-template-rows: repeat(5, auto);
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-rows: repeat(5, minmax(52px, 1fr));
   gap: 8px;
   padding: 12px;
+  min-height: 0;
 }
 
 .owcal .owcal-day{ 
@@ -197,12 +217,29 @@
   border: 2px outset #999;
   padding: 6px 7px;
   cursor: pointer;
-  min-height: 46px;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .owcal .owcal-day:hover{ outline: 2px dashed #900; outline-offset: 1px; }
 /* Two-line locked layout for day tiles */
-.owcal .owcal-dayName{ display:block; font-weight: bold; }
-.owcal .owcal-dayNum{ display:block; margin-top: 2px; font-weight: bold; }
+.owcal .owcal-dayName{
+  display:block;
+  font-weight: bold;
+  line-height:1.12;
+  font-size: clamp(0.78rem, 0.78vw, 0.92rem);
+  overflow-wrap:anywhere;
+}
+.owcal .owcal-dayNum{
+  display:block;
+  margin-top: 2px;
+  font-weight: bold;
+  line-height:1.08;
+  font-size: clamp(0.76rem, 0.72vw, 0.88rem);
+}
 
 .owcal .owcal-today{ box-shadow: inset 0 0 0 2px #900; }
 .owcal .owcal-holiday{ background: #fffae0; border-color: #900; }

--- a/parsklands.html
+++ b/parsklands.html
@@ -52,8 +52,12 @@
 
   .calendar-wrap{
     flex:0 1 clamp(460px,42vw,620px);
-    min-width:0;
+    background:rgba(255,255,255,0.92);
+    padding:12px;
+    border:4px groove #222;
+    box-shadow:4px 4px 8px #555;
     font-family:'Baskervville',serif;
+    overflow:hidden;
     display:flex;
     align-self:center;
   }
@@ -69,8 +73,8 @@
 
   /* ======== BOOK ======== */
   .book-shell{
-    flex:1 1 clamp(700px,58vw,980px);
-    min-width:560px;
+    flex:0 1 clamp(540px,50vw,740px);
+    min-width:520px;
     display:flex;
     align-items:center;
   }
@@ -82,6 +86,21 @@
     display:flex;
     justify-content:center; /* centers scaled book visually */
     flex:1;
+  }
+
+  /* Keep current visual tuning while leaving merge-prone base blocks stable. */
+  .home-grid .calendar-wrap{
+    min-width:0;
+    background:transparent;
+    padding:0;
+    border:0;
+    box-shadow:none;
+    overflow:visible;
+  }
+
+  .home-grid .book-shell{
+    flex:1 1 clamp(700px,58vw,980px);
+    min-width:560px;
   }
 
   .spread{

--- a/parsklands.html
+++ b/parsklands.html
@@ -45,40 +45,42 @@
     margin:0 auto 18px;        /* centers the whole block */
     display:flex;
     justify-content:center;    /* centers the pair inside */
-    align-items:flex-start;
+    align-items:center;
     gap:24px;
   }
   .home-grid > *{ min-width:0; }
 
   .calendar-wrap{
-    flex:0 1 clamp(400px,38vw,540px);
-    background:rgba(255,255,255,0.92);
-    padding:12px;
-    border:4px groove #222;
-    box-shadow:4px 4px 8px #555;
+    flex:0 1 clamp(460px,42vw,620px);
     font-family:'Baskervville',serif;
-    overflow:hidden;
+    display:flex;
+    align-self:center;
   }
 
   .calendar-embed{
     width:100%;
-    height:720px;
+    height:100%;
+    min-height:620px;
     border:0;
     display:block;
+    flex:1;
   }
 
   /* ======== BOOK ======== */
   .book-shell{
-    flex:1 1 720px;
-    min-width:560px;
+    flex:0 1 clamp(540px,50vw,740px);
+    min-width:520px;
     display:flex;
+    align-items:center;
   }
 
   .book-scale-wrap{
     width:100%;
+    min-width:0;
     overflow:hidden;
     display:flex;
     justify-content:center; /* centers scaled book visually */
+    flex:1;
   }
 
   .spread{
@@ -163,11 +165,12 @@
   .toc a:hover{ text-decoration:underline; }
 
   html, body{ max-width:100%; overflow-x:hidden; }
-  img, iframe{ max-width:100%; height:auto; }
+  img{ max-width:100%; height:auto; }
 
   @media (max-width:900px){
     .home-grid{ flex-direction:column; align-items:stretch; gap:12px; }
     .book-shell{ min-width:0; }
+    .spread{ max-width:100%; }
     .calendar-embed{ height:620px; }
   }
 
@@ -267,6 +270,26 @@
     .then(r => r.text())
     .then(html => { document.getElementById("footer").innerHTML = html; })
     .catch(err => console.error("Footer failed to load.", err));
+
+  // Keep calendar panel visually matched to the book panel height.
+  const bookSpread = document.getElementById("bookSpread");
+  const calendarWrap = document.querySelector(".calendar-wrap");
+
+  function syncCalendarHeight(){
+    if (!bookSpread || !calendarWrap || window.innerWidth <= 900) {
+      if (calendarWrap) calendarWrap.style.height = "";
+      return;
+    }
+    const h = Math.ceil(bookSpread.getBoundingClientRect().height);
+    if (h > 0) calendarWrap.style.height = `${h}px`;
+  }
+
+  window.addEventListener("load", syncCalendarHeight);
+  window.addEventListener("resize", syncCalendarHeight);
+
+  if (window.ResizeObserver && bookSpread) {
+    new ResizeObserver(syncCalendarHeight).observe(bookSpread);
+  }
 
 </script>
 </body>

--- a/parsklands.html
+++ b/parsklands.html
@@ -41,17 +41,18 @@
 
   /* ======== CENTERED TWO-COLUMN LAYOUT ======== */
   .home-grid{
-    max-width:1700px;
+    max-width:1680px;
     margin:0 auto 18px;        /* centers the whole block */
     display:flex;
     justify-content:center;    /* centers the pair inside */
     align-items:center;
-    gap:24px;
+    gap:18px;
   }
   .home-grid > *{ min-width:0; }
 
   .calendar-wrap{
-    flex:0 1 clamp(460px,42vw,620px);
+    flex:0 1 clamp(360px,34vw,500px);
+    min-width:0;
     font-family:'Baskervville',serif;
     display:flex;
     align-self:center;
@@ -60,7 +61,7 @@
   .calendar-embed{
     width:100%;
     height:100%;
-    min-height:620px;
+    min-height:600px;
     border:0;
     display:block;
     flex:1;
@@ -68,8 +69,8 @@
 
   /* ======== BOOK ======== */
   .book-shell{
-    flex:0 1 clamp(540px,50vw,740px);
-    min-width:520px;
+    flex:1 1 clamp(700px,58vw,980px);
+    min-width:560px;
     display:flex;
     align-items:center;
   }
@@ -106,7 +107,7 @@
   }
 
   .book-page{
-    padding:clamp(18px,2.6vw,34px);
+    padding:clamp(14px,2vw,26px);
     position:relative;
     min-width:0;
   }
@@ -171,7 +172,7 @@
     .home-grid{ flex-direction:column; align-items:stretch; gap:12px; }
     .book-shell{ min-width:0; }
     .spread{ max-width:100%; }
-    .calendar-embed{ height:620px; }
+    .calendar-embed{ min-height:620px; height:620px; }
   }
 
   @media (max-width:800px){

--- a/parsklands.html
+++ b/parsklands.html
@@ -46,7 +46,7 @@
     display:flex;
     justify-content:center;    /* centers the pair inside */
     align-items:center;
-    gap:18px;
+    gap:24px;
   }
   .home-grid > *{ min-width:0; }
 
@@ -61,7 +61,7 @@
   .calendar-embed{
     width:100%;
     height:100%;
-    min-height:600px;
+    min-height:620px;
     border:0;
     display:block;
     flex:1;
@@ -133,7 +133,7 @@
     display:flex;
     justify-content:flex-end;
     align-items:baseline;
-    gap:18px;
+    gap:24px;
     font-size:clamp(18px,2.2vw,26px);
   }
 
@@ -172,7 +172,7 @@
     .home-grid{ flex-direction:column; align-items:stretch; gap:12px; }
     .book-shell{ min-width:0; }
     .spread{ max-width:100%; }
-    .calendar-embed{ min-height:620px; height:620px; }
+    .calendar-embed{ height:620px; }
   }
 
   @media (max-width:800px){

--- a/parsklands.html
+++ b/parsklands.html
@@ -51,7 +51,7 @@
   .home-grid > *{ min-width:0; }
 
   .calendar-wrap{
-    flex:0 1 clamp(360px,34vw,500px);
+    flex:0 1 clamp(460px,42vw,620px);
     min-width:0;
     font-family:'Baskervville',serif;
     display:flex;


### PR DESCRIPTION
### Motivation
- Fix layout issues so the calendar scrolls horizontally as a 12‑page scroller and the top overview blurb behaves correctly.
- Improve sizing and overflow handling so calendar and book panels align and avoid stacking or overflow on narrow viewports. 
- Replace brittle background gifs and hardcoded sizing with responsive CSS and safer grid/flex patterns.

### Description
- Updated `calendar.html` CSS to use flex/grid layouts, added `font-size`, `line-height`, `min-height`/`min-width` and `minmax(0, 1fr)` grid columns to prevent overflow and stacking, and set the month page to a grid with explicit rows for predictable sizing.  
- Adjusted day/week sizing with `clamp()` for responsive fonts, converted day tiles to flex columns, and tuned scroll-snap + overflow rules so the month scroller works horizontally and fills available height.  
- Replaced repeated background GIFs with a linear-gradient for `.owcal-specialHead` and `.owcal-monthHead`, cleaned up rule ordering, and tightened several styles (buttons, topbar, shell) for consistent rendering.  
- Updated `parsklands.html` layout: changed alignment, increased `calendar-wrap` and `calendar-embed` sizing and responsiveness, adjusted `book-shell`/`book-scale-wrap` flex rules and min-widths, removed a broad `iframe` sizing rule, and added responsive tweaks for smaller viewports.  
- Added client-side script in `parsklands.html` to keep the calendar panel height matched to the book spread using `ResizeObserver` and `load/resize` listeners, and guarded behavior for small screens.  

### Testing
- No automated tests were run for these UI/CSS/HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3af90087c83248d0fbd08ce1e5a28)