### PR TITLE
Remove redundant '30 days' label from calendar month headers

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -617,7 +617,6 @@ function render(){
     head.innerHTML = `
       <div class="owcal-headLabelBackdrop">
         <div class="owcal-monthTitle">${esc(meta.season)} - ${esc(meta.name)} - ${esc(meta.zodiac)}</div>
-        <div class="owcal-monthMeta">30 days</div>
       </div>
     `;
     page.appendChild(head);


### PR DESCRIPTION
### Motivation
- Remove the redundant “30 days” metadata under each calendar month header to keep the month header cleaner since all months are 30 days.

### Description
- Deleted the `<div class="owcal-monthMeta">30 days</div>` element from the month header in `calendar.html` so the header now only shows the season/month/zodiac title.

### Testing
- Served the site with `python -m http.server 8000` and loaded `calendar.html`, then captured a Playwright screenshot to confirm month headers render correctly without the "30 days" line.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73a118f2c832495630b9dac71b936)