### PR TITLE
Add text-shadow to calendar titles and remove hardcoded "30 days" meta

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -134,7 +134,7 @@
 .owcal .owcal-specialTitle{
   font-weight: bold;
   color: #ffffff;
-  text-shadow: none;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.75);
   font-size: 1.05em;
   letter-spacing: 0.5px;
   font-family: inherit;
@@ -173,7 +173,7 @@
 .owcal .owcal-monthTitle{
   font-weight: bold;
   color: #ffffff;
-  text-shadow: none;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.75);
   font-size: 1.05em;
   letter-spacing: 0.5px;
   font-family: inherit;   /* follow site stylesheet */
@@ -617,7 +617,6 @@ function render(){
     head.innerHTML = `
       <div class="owcal-headLabelBackdrop">
         <div class="owcal-monthTitle">${esc(meta.season)} - ${esc(meta.name)} - ${esc(meta.zodiac)}</div>
-        <div class="owcal-monthMeta">30 days</div>
       </div>
     `;
     page.appendChild(head);


### PR DESCRIPTION
### Motivation

- Improve title readability when month/special header uses background artwork by adding a subtle drop shadow to the title text.
- Remove a misleading hardcoded "30 days" metadata element from the month header so month metadata can be handled dynamically.

### Description

- Updated CSS for `.owcal-specialTitle` and `.owcal-monthTitle` to use `text-shadow: 0 2px 4px rgba(0,0,0,0.75)` instead of `text-shadow: none`.
- Removed the static `<div class="owcal-monthMeta">30 days</div>` from the month header HTML template in `render()` so month metadata is no longer hardcoded.

### Testing

- No automated tests were added or run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73a118f2c832495630b9dac71b936)