### PR TITLE
Widen book spread area on parsklands page

### DIFF
--- a/parsklands.html
+++ b/parsklands.html
@@ -69,7 +69,7 @@
 
   /* ======== BOOK ======== */
   .book-shell{
-    flex:0 1 clamp(540px,50vw,740px);
+    flex:0 1 clamp(640px,58vw,920px);
     min-width:520px;
     display:flex;
     align-items:stretch;


### PR DESCRIPTION
### Motivation
- Make the book area wider on desktop/layouts while keeping the calendar panel exactly as-is.

### Description
- Change `.book-shell` CSS clamp in `parsklands.html` from `clamp(540px,50vw,740px)` to `clamp(640px,58vw,920px)` so the book panel expands horizontally without modifying calendar sizing rules.

### Testing
- Launched a local server with `python3 -m http.server 4173` and ran a Playwright script to load `parsklands.html` and capture `artifacts/parsklands-book-wider.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab292936bc832497755155ef4dd277)