### PR TITLE
Add UNDER CONSTRUCTION placeholder pages for Parsklands guide and storytelling links

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Atlas | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Atlas</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/creatures.html
+++ b/creatures.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Creatures | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Creatures</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/fables.html
+++ b/fables.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Voices and Fables | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Voices and Fables</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/glossary.html
+++ b/glossary.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Glossary | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Glossary</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/gods.html
+++ b/gods.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gods | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Gods</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/magic.html
+++ b/magic.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Magic | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Magic</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/old-friends.html
+++ b/old-friends.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Old Friends | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Old Friends</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/small-memories.html
+++ b/small-memories.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Small Memories | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Small Memories</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/timeline.html
+++ b/timeline.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Timeline | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Timeline</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>

--- a/words-of-parsk.html
+++ b/words-of-parsk.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Words of Parsk | Door to the Parsklands</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
+  <style>
+    main {
+      min-height: 100vh;
+      padding: 36px 16px 64px;
+      font-family: 'Baskervville', serif;
+    }
+
+    .page-shell {
+      max-width: 860px;
+      margin: 40px auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 4px groove #222;
+      box-shadow: 4px 4px 8px #555;
+      padding: 28px 24px;
+      text-align: center;
+    }
+
+    .construction-sign {
+      margin: 0 0 20px;
+      font-size: clamp(24px, 4vw, 42px);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-decoration: underline;
+      text-underline-offset: 8px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 3vw, 34px);
+    }
+
+    p {
+      margin: 0;
+      font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="page-shell">
+      <div class="construction-sign">UNDER CONSTRUCTION</div>
+      <h1>Words of Parsk</h1>
+      <p>This page is being prepared and will be available soon.</p>
+    </section>
+  </main>
+
+  <div id="footer"></div>
+
+  <script>
+    fetch("header.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("header").innerHTML = html; })
+      .catch(err => console.error("Header failed to load.", err));
+
+    fetch("footer.html")
+      .then(r => r.text())
+      .then(html => { document.getElementById("footer").innerHTML = html; })
+      .catch(err => console.error("Footer failed to load.", err));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a landing page for every link listed under the Field Guides and Storytelling sections on `parsklands.html` so users don't hit 404s and the site appearance remains consistent. 
- Keep new pages visually consistent with the rest of the site by reusing the shared stylesheet and site chrome.

### Description
- Added 10 placeholder HTML pages: `atlas.html`, `magic.html`, `creatures.html`, `gods.html`, `timeline.html`, `glossary.html`, `words-of-parsk.html`, `fables.html`, `small-memories.html`, and `old-friends.html`.
- Each page follows the site layout (loads `style.css` and the Google `Baskervville` font), renders a centered `.page-shell` content area, shows a prominent `UNDER CONSTRUCTION` sign, and includes the same `fetch` logic to inject `header.html` and `footer.html`.
- Files were added and committed to the repository so the links in `parsklands.html` now resolve to real pages.

### Testing
- Confirmed link coverage using a small Python script that extracted `href` values from `parsklands.html` and verified each target file exists; all 10 targets exist (success).
- Served the site locally with `python -m http.server --directory /workspace/github.io` and used a Playwright-driven browser run (Firefox) to capture a screenshot of `atlas.html` for visual verification (screenshot capture succeeded).
- Attempted a `BeautifulSoup` (`bs4`) parse as an additional check, but the `bs4` import failed in the environment (module not installed), so a regex-based existence check was used instead (fallback used successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2b7928dc8324984e51f636d29804)