### PR TITLE
Add Atlas page and `atlas-data.js` with editable region/country cards

### DIFF
--- a/atlas-data.js
+++ b/atlas-data.js
@@ -1,0 +1,87 @@
+window.ATLAS_PAGE_DATA = {
+  pageTitle: "Atlas",
+  heroMap: {
+    src: "assets/background.jpg",
+    alt: "Placeholder map of the world"
+  },
+  intro: "A living world map and country register. Use the editable cards below to define each nation by region.",
+  regions: [
+    {
+      name: "Northern Reach",
+      countries: [
+        {
+          name: "Landland",
+          images: [
+            { src: "assets/background.jpg", alt: "Landland landscape placeholder" }
+          ],
+          crestSelf: "Dragon",
+          crestWorld: "Lizard",
+          government: "Autocracy",
+          terrainWeather: "Swamp, rainy",
+          peopleTrades: "Gnomes, quilt makers",
+          timeline: [
+            {
+              event: "Event 1",
+              year: "69",
+              ruler: "Ruler Name",
+              population: "300",
+              details: "Blah blah blah"
+            },
+            {
+              event: "Event 2",
+              year: "404",
+              ruler: "Ruler Name",
+              population: "1500",
+              details: "Blah blah blah"
+            }
+          ]
+        },
+        {
+          name: "...",
+          images: [
+            { src: "assets/background.jpg", alt: "Placeholder country image" }
+          ],
+          crestSelf: "...",
+          crestWorld: "...",
+          government: "...",
+          terrainWeather: "...",
+          peopleTrades: "...",
+          timeline: [
+            {
+              event: "...",
+              year: "...",
+              ruler: "...",
+              population: "...",
+              details: "..."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      name: "Central Expanse",
+      countries: [
+        {
+          name: "...",
+          images: [
+            { src: "assets/background.jpg", alt: "Placeholder country image" }
+          ],
+          crestSelf: "...",
+          crestWorld: "...",
+          government: "...",
+          terrainWeather: "...",
+          peopleTrades: "...",
+          timeline: [
+            {
+              event: "...",
+              year: "...",
+              ruler: "...",
+              population: "...",
+              details: "..."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};

--- a/atlas.html
+++ b/atlas.html
@@ -13,34 +13,129 @@
       font-family: 'Baskervville', serif;
     }
 
-    .page-shell {
-      max-width: 860px;
+    .atlas-shell {
+      max-width: 980px;
       margin: 40px auto;
-      background: rgba(255, 255, 255, 0.95);
+      background: rgba(255, 255, 255, 0.93);
       border: 4px groove #222;
       box-shadow: 4px 4px 8px #555;
       padding: 28px 24px;
+    }
+
+    .atlas-heading {
       text-align: center;
+      margin-bottom: 26px;
     }
 
-    .construction-sign {
-      margin: 0 0 20px;
-      font-size: clamp(24px, 4vw, 42px);
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      text-decoration: underline;
-      text-underline-offset: 8px;
+    .atlas-heading h1 {
+      margin: 0 0 16px;
+      font-size: clamp(30px, 4vw, 44px);
     }
 
-    h1 {
-      margin: 0 0 12px;
-      font-size: clamp(24px, 3vw, 34px);
+    .atlas-map {
+      width: min(100%, 760px);
+      margin: 0 auto 16px;
+      display: block;
+      border: 3px solid #222;
+      box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.2);
     }
 
-    p {
+    .atlas-intro {
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
+      line-height: 1.45;
+    }
+
+    .atlas-region {
+      margin-top: 24px;
+    }
+
+    .atlas-region h2 {
+      margin: 0 0 12px;
+      border-bottom: 2px solid #444;
+      padding-bottom: 6px;
+      font-size: clamp(26px, 3vw, 34px);
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+    }
+
+    .atlas-country-list {
+      display: grid;
+      gap: 14px;
+    }
+
+    .atlas-country-card {
+      border: 3px groove #333;
+      background: rgba(255, 255, 255, 0.9);
+      padding: 14px 16px;
+    }
+
+    .atlas-country-card h3 {
+      margin: 0 0 10px;
+      font-size: clamp(24px, 3vw, 32px);
+      border-bottom: 1px solid #444;
+      padding-bottom: 6px;
+    }
+
+    .atlas-country-images {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+      margin-bottom: 10px;
+    }
+
+    .atlas-country-images img {
+      width: 100%;
+      display: block;
+      border: 2px solid #333;
+      box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.2);
+    }
+
+    .atlas-fields {
+      margin: 0;
+      display: grid;
+      grid-template-columns: minmax(190px, auto) 1fr;
+      gap: 8px 12px;
+      font-size: 18px;
+      line-height: 1.45;
+    }
+
+    .atlas-fields dt {
+      font-weight: bold;
+    }
+
+    .atlas-fields dd {
+      margin: 0;
+    }
+
+    .atlas-timeline {
+      margin: 10px 0 0;
+      padding-left: 18px;
+      font-size: 18px;
       line-height: 1.4;
+    }
+
+    .atlas-timeline li + li {
+      margin-top: 8px;
+    }
+
+    .atlas-help {
+      margin: 20px 0 0;
+      border: 2px dashed #333;
+      background: rgba(255, 255, 255, 0.72);
+      padding: 10px 12px;
+      font-size: 16px;
+    }
+
+    code {
+      background: rgba(0, 0, 0, 0.07);
+      padding: 1px 4px;
+    }
+
+    @media (max-width: 700px) {
+      .atlas-fields {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
@@ -48,25 +143,133 @@
   <div id="header"></div>
 
   <main>
-    <section class="page-shell">
-      <div class="construction-sign">UNDER CONSTRUCTION</div>
-      <h1>Atlas</h1>
-      <p>This page is being prepared and will be available soon.</p>
+    <section class="atlas-shell">
+      <header class="atlas-heading">
+        <h1 id="atlas-page-title">Atlas</h1>
+        <img id="atlas-map" class="atlas-map" src="assets/background.jpg" alt="Placeholder map" />
+        <p id="atlas-page-intro" class="atlas-intro">Loading atlas entries...</p>
+      </header>
+
+      <div id="atlas-regions"></div>
+
+      <p class="atlas-help">Edit <code>atlas-data.js</code> to update regions, countries, and timeline cards for this page.</p>
     </section>
   </main>
 
   <div id="footer"></div>
 
+  <script src="atlas-data.js"></script>
   <script>
+    function renderAtlasPage(atlasData) {
+      const titleEl = document.getElementById("atlas-page-title");
+      const mapEl = document.getElementById("atlas-map");
+      const introEl = document.getElementById("atlas-page-intro");
+      const regionsEl = document.getElementById("atlas-regions");
+
+      titleEl.textContent = atlasData.pageTitle || "Atlas";
+      mapEl.src = atlasData.heroMap?.src || "assets/background.jpg";
+      mapEl.alt = atlasData.heroMap?.alt || "Placeholder map";
+      introEl.textContent = atlasData.intro || "";
+      regionsEl.innerHTML = "";
+
+      atlasData.regions.forEach((region) => {
+        const regionSection = document.createElement("section");
+        regionSection.className = "atlas-region";
+
+        const regionHeading = document.createElement("h2");
+        regionHeading.textContent = region.name || "...";
+        regionSection.appendChild(regionHeading);
+
+        const countryList = document.createElement("div");
+        countryList.className = "atlas-country-list";
+
+        region.countries.forEach((country) => {
+          const countryCard = document.createElement("article");
+          countryCard.className = "atlas-country-card";
+
+          const countryName = document.createElement("h3");
+          countryName.textContent = country.name || "...";
+          countryCard.appendChild(countryName);
+
+          const imageWrap = document.createElement("div");
+          imageWrap.className = "atlas-country-images";
+
+          (country.images || [{ src: "assets/background.jpg", alt: "Placeholder country image" }]).forEach((image) => {
+            const countryImage = document.createElement("img");
+            countryImage.src = image.src || "assets/background.jpg";
+            countryImage.alt = image.alt || "Placeholder country image";
+            imageWrap.appendChild(countryImage);
+          });
+
+          countryCard.appendChild(imageWrap);
+
+          const fields = document.createElement("dl");
+          fields.className = "atlas-fields";
+
+          const cardFields = {
+            "Crest": `Self (${country.crestSelf || "..."}) | World (${country.crestWorld || "..."})`,
+            "Government": country.government,
+            "Terrain/Weather": country.terrainWeather,
+            "People/Trades": country.peopleTrades
+          };
+
+          Object.entries(cardFields).forEach(([label, value]) => {
+            const term = document.createElement("dt");
+            term.textContent = `${label} -`;
+            fields.appendChild(term);
+
+            const description = document.createElement("dd");
+            description.textContent = value || "...";
+            fields.appendChild(description);
+          });
+
+          countryCard.appendChild(fields);
+
+          const timelineList = document.createElement("ul");
+          timelineList.className = "atlas-timeline";
+
+          (country.timeline || []).forEach((entry) => {
+            const item = document.createElement("li");
+            const eventName = entry.event || "...";
+            const year = entry.year || "...";
+            const ruler = entry.ruler || "...";
+            const population = entry.population || "...";
+            const details = entry.details || "...";
+            item.textContent = `${eventName}, Year ${year} - ${ruler} - Population ${population}. ${details}`;
+            timelineList.appendChild(item);
+          });
+
+          if (!timelineList.children.length) {
+            const emptyItem = document.createElement("li");
+            emptyItem.textContent = "..., Year ... - ... - Population .... ...";
+            timelineList.appendChild(emptyItem);
+          }
+
+          countryCard.appendChild(timelineList);
+          countryList.appendChild(countryCard);
+        });
+
+        regionSection.appendChild(countryList);
+        regionsEl.appendChild(regionSection);
+      });
+    }
+
     fetch("header.html")
-      .then(r => r.text())
-      .then(html => { document.getElementById("header").innerHTML = html; })
-      .catch(err => console.error("Header failed to load.", err));
+      .then((r) => r.text())
+      .then((html) => { document.getElementById("header").innerHTML = html; })
+      .catch((err) => console.error("Header failed to load.", err));
 
     fetch("footer.html")
-      .then(r => r.text())
-      .then(html => { document.getElementById("footer").innerHTML = html; })
-      .catch(err => console.error("Footer failed to load.", err));
+      .then((r) => r.text())
+      .then((html) => { document.getElementById("footer").innerHTML = html; })
+      .catch((err) => console.error("Footer failed to load.", err));
+
+    renderAtlasPage(window.ATLAS_PAGE_DATA || {
+      pageTitle: "Atlas",
+      heroMap: { src: "assets/background.jpg", alt: "Placeholder map" },
+      intro: "",
+      regions: []
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the previous "under construction" placeholder with a functional Atlas layout that matches other field pages and is easy to populate. 
- Provide a simple data-driven format so regions, countries, and timelines can be edited without touching page markup.

### Description
- Replaced `atlas.html` content with a full page layout (title, hero map, intro, region sections, and styled country cards) and moved rendering into in-page JavaScript. 
- Implemented dynamic rendering for regions, country images, crest formatting (`Self (...) | World (...)`), core fields (`Government`, `Terrain/Weather`, `People/Trades`) and timeline entries. 
- Added `atlas-data.js` containing editable placeholder/example data including the provided Landland example and `...` starter cards. 
- Included on-page guidance directing editors to update `atlas-data.js` and added responsive styling to match existing site patterns.

### Testing
- Served the site locally with `python3 -m http.server 4173` and verified `atlas.html` loaded successfully. (succeeded)
- Ran a Playwright script to open `http://127.0.0.1:4173/atlas.html` and capture a full-page screenshot to confirm visual structure and card rendering. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acbbe4b1c483249bfc3386cd7ecb3d)