### PR TITLE
Add subtle text-shadow to typography across site pages

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -30,6 +30,7 @@
     .atlas-heading h1 {
       margin: 0 0 16px;
       font-size: clamp(30px, 4vw, 44px);
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .atlas-map {
@@ -44,6 +45,7 @@
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
       line-height: 1.45;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .atlas-region {
@@ -57,6 +59,7 @@
       font-size: clamp(26px, 3vw, 34px);
       text-transform: uppercase;
       letter-spacing: 0.6px;
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .atlas-region-media {
@@ -78,6 +81,7 @@
       margin: 0;
       font-size: 18px;
       line-height: 1.45;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .atlas-country-list {
@@ -96,6 +100,7 @@
       font-size: clamp(24px, 3vw, 32px);
       border-bottom: 1px solid #444;
       padding-bottom: 6px;
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .atlas-country-images {
@@ -123,10 +128,12 @@
 
     .atlas-fields dt {
       font-weight: bold;
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .atlas-fields dd {
       margin: 0;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .atlas-timeline {

--- a/creatures.html
+++ b/creatures.html
@@ -30,6 +30,7 @@
     .creatures-heading h1 {
       margin: 0 0 18px;
       font-size: clamp(28px, 4vw, 42px);
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .creatures-image {
@@ -44,6 +45,7 @@
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
       line-height: 1.4;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .creature-list {
@@ -62,6 +64,7 @@
       font-size: clamp(24px, 3vw, 32px);
       border-bottom: 1px solid #444;
       padding-bottom: 6px;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .creature-fields {
@@ -75,10 +78,12 @@
 
     .creature-fields dt {
       font-weight: bold;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .creature-fields dd {
       margin: 0;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .creatures-help {

--- a/glossary.html
+++ b/glossary.html
@@ -27,6 +27,7 @@
       font-size: clamp(28px, 4vw, 40px);
       text-align: center;
       letter-spacing: 1px;
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .intro {
@@ -34,6 +35,7 @@
       text-align: center;
       font-size: clamp(16px, 1.8vw, 21px);
       line-height: 1.45;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .alphabet-nav {
@@ -137,11 +139,13 @@
       font-size: 1.06rem;
       text-decoration: underline;
       font-weight: bold;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .entry-definition {
       margin: 0;
       line-height: 1.35;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .motifs {

--- a/magic.html
+++ b/magic.html
@@ -30,11 +30,13 @@
     .magic-heading h1 {
       margin: 0 0 10px;
       font-size: clamp(28px, 4vw, 40px);
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .magic-heading p {
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .tab-row {
@@ -84,6 +86,7 @@
       font-size: clamp(22px, 3vw, 30px);
       border-bottom: 1px solid #555;
       padding-bottom: 4px;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .alchemy-cards {
@@ -100,6 +103,7 @@
     .alchemy-card h3 {
       margin: 0 0 8px;
       font-size: 24px;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .alchemy-fields {
@@ -113,10 +117,12 @@
 
     .alchemy-fields dt {
       font-weight: bold;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .alchemy-fields dd {
       margin: 0;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .alchemy-help {

--- a/timeline.html
+++ b/timeline.html
@@ -30,12 +30,14 @@
     .timeline-heading h1 {
       margin: 0 0 8px;
       font-size: clamp(26px, 4vw, 40px);
+      text-shadow: 0 0 6px rgba(255, 255, 255, 0.95), 0 0 2px rgba(255, 255, 255, 0.98);
     }
 
     .timeline-heading p {
       margin: 0;
       font-size: clamp(18px, 2vw, 22px);
       line-height: 1.4;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .timeline {
@@ -99,6 +101,7 @@
       font-family: inherit;
       font-size: clamp(18px, 2vw, 24px);
       cursor: pointer;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .event-title[aria-expanded="true"] {
@@ -123,6 +126,7 @@
     .event-card h3 {
       margin: 0 0 6px;
       font-size: 28px;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .event-years,
@@ -130,10 +134,12 @@
     .event-note {
       margin: 0 0 8px;
       font-style: italic;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .event-summary {
       margin: 0 0 10px;
+      text-shadow: 0 0 5px rgba(255, 255, 255, 0.92);
     }
 
     .event-image {


### PR DESCRIPTION
### Motivation
- Improve legibility and visual depth of on-page typography against varied backgrounds by adding subtle `text-shadow` accents. 
- Create a consistent typographic treatment across multiple content pages for a more cohesive look and feel. 
- Reduce perceived harshness of high-contrast borders and backgrounds by softening text edges.

### Description
- Added `text-shadow` declarations to headings, introductory paragraphs, field labels and values, and card titles in `atlas.html`, `creatures.html`, `glossary.html`, `magic.html`, and `timeline.html` to apply a subtle glow effect. 
- Updated multiple selectors including `h1`/`h2`/`h3` variants, intro/description classes, field `dt`/`dd`, and event/title elements to use consistent shadow parameters. 
- Kept existing layout, spacing, and other styles unchanged so the changes are purely presentational and limited to CSS within each HTML file. 

### Testing
- No automated tests were run for these presentational changes. 
- Changes were limited to static CSS in HTML files to minimize risk to functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc4a09b848324b19658c9891eb01a)