### PR TITLE
Improve mobile compatibility for shared hero and global layout styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
   <div id="header"></div>
 
   <!-- Dragon flanked galaxy box -->
-<div style="display: flex; justify-content: center; align-items: center; gap: 60px; margin: 60px auto; max-width: 1000px;">
-  <div style="display: flex; flex-direction: column; align-items: center; gap: 40px;">
+<div class="hero-shell">
+  <div class="hero-rail">
     <img src="https://blob.gifcities.org/gifcities/NG45PUZDMZYH4N5AEGQILJ4Z6IINUDAU.gif" alt="divider gif" style="height: 60px;" />
     <img src="https://blob.gifcities.org/gifcities/BOTFWRIH6HC7V4IZC6D247453YKBRM72.gif" alt="dragon left"
          style="transform: scale(1.5); height: 120px;" />
@@ -41,7 +41,7 @@
       </ul>
     </div>
 
-      <div style="display: flex; flex-direction: column; align-items: center; gap: 40px;">
+      <div class="hero-rail">
     <img src="https://blob.gifcities.org/gifcities/NG45PUZDMZYH4N5AEGQILJ4Z6IINUDAU.gif" alt="divider gif" style="height: 60px;" />
     <img src="https://blob.gifcities.org/gifcities/BOTFWRIH6HC7V4IZC6D247453YKBRM72.gif" alt="dragon right"
          style="transform: scaleX(-1) scale(1.5); height: 120px;" />

--- a/site-policies.html
+++ b/site-policies.html
@@ -14,9 +14,9 @@
   <div id="header"></div>
 
   <!-- Dragon flanked galaxy box -->
-<div style="display: flex; justify-content: center; align-items: center; gap: 60px; margin: 60px auto; max-width: 1000px;">
+<div class="hero-shell">
 
-  <div style="display: flex; flex-direction: column; align-items: center; gap: 40px;">
+  <div class="hero-rail">
     <img src="https://blob.gifcities.org/gifcities/NG45PUZDMZYH4N5AEGQILJ4Z6IINUDAU.gif" alt="divider gif" style="height: 60px; margin: 10px 0;" />
     <img src="https://blob.gifcities.org/gifcities/ZJZF3Y3X2WQLXABBLDRWF7ANKI4D2WY6.gif" alt="guardian left"
          style="transform: scaleX(-1) scale(2.5); height: 120px; margin-top: 60px; margin-bottom: 60px;" />
@@ -45,7 +45,7 @@
     </div>
   </div>
 
-  <div style="display: flex; flex-direction: column; align-items: center; gap: 40px;">
+  <div class="hero-rail">
     <img src="https://blob.gifcities.org/gifcities/NG45PUZDMZYH4N5AEGQILJ4Z6IINUDAU.gif" alt="divider gif" style="height: 60px; margin: 10px 0;" />
     <img src="https://blob.gifcities.org/gifcities/ZJZF3Y3X2WQLXABBLDRWF7ANKI4D2WY6.gif" alt="guardian right"
          style="transform: scale(2.5); height: 120px; margin-top: 60px; margin-bottom: 60px;" />
@@ -53,10 +53,6 @@
   </div>
 
 </div>
-
-      
-  </div>
-
 
   <div id="footer"></div>
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -8,6 +12,11 @@ body {
   background-position: center;
   background-attachment: fixed;
   background-repeat: no-repeat;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
 }
 
 header {
@@ -205,6 +214,22 @@ nav a:hover {
   transform: scale(1.02);
 }
 
+.hero-shell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 60px;
+  margin: 60px auto;
+  max-width: 1000px;
+}
+
+.hero-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+}
+
 #modal {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;
@@ -259,6 +284,31 @@ nav a:hover {
 }
 
 @media (max-width: 700px) {
+  header {
+    padding: 24px 14px;
+  }
+
+  .site-title {
+    font-size: 2.1em;
+    padding: 8px 14px;
+  }
+
+  footer {
+    padding: 20px 12px;
+  }
+
+  .hero-shell {
+    flex-direction: column;
+    gap: 20px;
+    margin: 30px auto;
+    padding: 0 10px;
+  }
+
+  .hero-rail {
+    flex-direction: row;
+    gap: 16px;
+  }
+
   nav ul {
     flex-direction: column;
     gap: 10px;
@@ -267,6 +317,7 @@ nav a:hover {
   .content {
     flex-direction: column;
     align-items: stretch;
+    padding: 24px 16px;
   }
 
   img[alt="dragon left"],


### PR DESCRIPTION
### Motivation
- Improve overall mobile presentation and prevent layout overflow while preserving the existing desktop look and spacing. 

### Description
- Added global mobile-safe CSS in `style.css` by setting `* { box-sizing: border-box; }` and responsive images via `img { max-width: 100%; height: auto; }` to reduce overflow issues. 
- Introduced reusable `.hero-shell` and `.hero-rail` classes and replaced rigid inline flex containers in `index.html` and `site-policies.html` so the flanked hero sections can stack cleanly on small screens. 
- Added targeted small-screen adjustments under `@media (max-width: 700px)` to reduce header/footer padding, scale `.site-title`, change hero layout stacking, and tighten `.content` padding. 
- Removed an extra stray closing `</div>` in `site-policies.html` to avoid inconsistent rendering. 

### Testing
- Ran `git diff --check` to ensure no whitespace/patch problems and it passed. 
- Launched a local server with `python -m http.server` and validated rendering with Playwright screenshots at mobile `390x844` and desktop `1440x900`. 
- Captured full-page screenshots for `index.html` and `site-policies.html` at mobile size and `index.html` at desktop size to confirm the mobile stacking and unchanged desktop layout, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc756371c8324b83ad2a7f64fc5ff)