### PR TITLE
Add toggleable under-construction overlay for Parsklands pages

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -315,5 +315,6 @@
       regions: []
     });
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/creatures.html
+++ b/creatures.html
@@ -183,5 +183,6 @@
       document.getElementById("creatures-page-intro").textContent = "Creature field guide data failed to load.";
     }
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/fables.html
+++ b/fables.html
@@ -68,5 +68,6 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/glossary.html
+++ b/glossary.html
@@ -321,5 +321,6 @@
       })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/magic.html
+++ b/magic.html
@@ -267,5 +267,6 @@
       document.getElementById("panel-alchemy").innerHTML = '<p class="magic-placeholder">Alchemy guide data failed to load.</p>';
     }
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/old-friends.html
+++ b/old-friends.html
@@ -68,5 +68,6 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/small-memories.html
+++ b/small-memories.html
@@ -68,5 +68,6 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/timeline.html
+++ b/timeline.html
@@ -284,5 +284,6 @@
       document.getElementById("timeline-page-subtitle").textContent = "Timeline data failed to load.";
     }
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/under-construction.js
+++ b/under-construction.js
@@ -1,0 +1,82 @@
+(() => {
+  // Flip this to false when you are ready to launch your page content.
+  const UNDER_CONSTRUCTION_MODE = true;
+
+  const pagesUnderConstruction = new Set([
+    "atlas.html",
+    "magic.html",
+    "creatures.html",
+    "timeline.html",
+    "glossary.html",
+    "words-of-parsk.html",
+    "fables.html",
+    "small-memories.html",
+    "old-friends.html"
+  ]);
+
+  const currentPage = window.location.pathname.split("/").pop() || "index.html";
+
+  if (!UNDER_CONSTRUCTION_MODE || !pagesUnderConstruction.has(currentPage)) {
+    return;
+  }
+
+  const main = document.querySelector("main");
+  if (!main) {
+    return;
+  }
+
+  const title = document.title.split("|")[0].trim() || "This page";
+
+  for (const child of Array.from(main.children)) {
+    child.hidden = true;
+  }
+
+  const sign = document.createElement("section");
+  sign.className = "uc-sign";
+  sign.innerHTML = `
+    <h1>UNDER CONSTRUCTION</h1>
+    <p>${title} is currently being prepared.</p>
+    <p class="uc-note">Set <code>UNDER_CONSTRUCTION_MODE</code> to <code>false</code> in <code>under-construction.js</code> when you are ready to launch.</p>
+  `;
+
+  main.appendChild(sign);
+
+  if (!document.getElementById("uc-sign-style")) {
+    const style = document.createElement("style");
+    style.id = "uc-sign-style";
+    style.textContent = `
+      .uc-sign {
+        max-width: min(92vw, 860px);
+        margin: 48px auto;
+        background: rgba(255, 255, 255, 0.95);
+        border: 4px groove #222;
+        box-shadow: 4px 4px 8px #555;
+        padding: clamp(24px, 4vw, 40px) clamp(20px, 4vw, 30px);
+        text-align: center;
+        font-family: 'Baskervville', serif;
+      }
+
+      .uc-sign h1 {
+        margin: 0 0 14px;
+        font-size: clamp(30px, 5vw, 54px);
+        letter-spacing: 1px;
+        text-transform: uppercase;
+        text-decoration: underline;
+        text-underline-offset: 8px;
+      }
+
+      .uc-sign p {
+        margin: 0;
+        font-size: clamp(18px, 2.4vw, 28px);
+        line-height: 1.35;
+      }
+
+      .uc-sign .uc-note {
+        margin-top: 16px;
+        font-size: clamp(14px, 1.7vw, 18px);
+        opacity: 0.9;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+})();

--- a/words-of-parsk.html
+++ b/words-of-parsk.html
@@ -68,5 +68,6 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="under-construction.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Temporarily hide incomplete book pages linked from `parsklands.html` and display a clear, easy-to-toggle "UNDER CONSTRUCTION" notice while content is being prepared.

### Description
- Added a shared script `under-construction.js` that, when enabled, hides everything inside the page's `<main>` and injects a styled "UNDER CONSTRUCTION" sign. 
- The behavior is controlled by a single boolean constant `UNDER_CONSTRUCTION_MODE` in `under-construction.js` so turning the overlay off is a one-line change. 
- Wired the script into the Parsklands pages by adding `<script src="under-construction.js"></script>` to `atlas.html`, `magic.html`, `creatures.html`, `timeline.html`, `glossary.html`, `words-of-parsk.html`, `fables.html`, `small-memories.html`, and `old-friends.html`. 
- The header/footer remain available so site navigation still works while page internals are hidden.

### Testing
- Confirmed each target page includes the helper by searching for `under-construction.js` in the updated files, and the check succeeded. 
- Served the site locally with `python -m http.server 4173` and inspected pages to ensure the sign appears and content is hidden, which worked as expected. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173/atlas.html` to validate the overlay rendering, and the screenshot confirmed the under-construction sign was shown and page content hidden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc8490fb083248e9788cd08cb6dd5)