### PR TITLE
Add subtle text-shadow glow to headings and key text across multiple pages

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -30,6 +30,7 @@
     .atlas-heading h1 {
       margin: 0 0 16px;
       font-size: clamp(30px, 4vw, 44px);
+      text-shadow: 0 0 14px rgba(255, 255, 255, 0.99), 0 0 8px rgba(255, 255, 255, 0.97), 1px 1px 0 rgba(255, 255, 255, 0.95);
     }
 
     .atlas-map {
@@ -44,6 +45,7 @@
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
       line-height: 1.45;
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96);
     }
 
     .atlas-region {
@@ -57,6 +59,7 @@
       font-size: clamp(26px, 3vw, 34px);
       text-transform: uppercase;
       letter-spacing: 0.6px;
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .atlas-region-media {
@@ -78,6 +81,7 @@
       margin: 0;
       font-size: 18px;
       line-height: 1.45;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .atlas-country-list {
@@ -96,6 +100,7 @@
       font-size: clamp(24px, 3vw, 32px);
       border-bottom: 1px solid #444;
       padding-bottom: 6px;
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .atlas-country-images {
@@ -123,10 +128,12 @@
 
     .atlas-fields dt {
       font-weight: bold;
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .atlas-fields dd {
       margin: 0;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .atlas-timeline {

--- a/creatures.html
+++ b/creatures.html
@@ -30,6 +30,7 @@
     .creatures-heading h1 {
       margin: 0 0 18px;
       font-size: clamp(28px, 4vw, 42px);
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .creatures-image {
@@ -44,6 +45,7 @@
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
       line-height: 1.4;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .creature-list {
@@ -62,6 +64,7 @@
       font-size: clamp(24px, 3vw, 32px);
       border-bottom: 1px solid #444;
       padding-bottom: 6px;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .creature-fields {
@@ -75,10 +78,12 @@
 
     .creature-fields dt {
       font-weight: bold;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .creature-fields dd {
       margin: 0;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .creatures-help {

--- a/glossary.html
+++ b/glossary.html
@@ -27,6 +27,7 @@
       font-size: clamp(28px, 4vw, 40px);
       text-align: center;
       letter-spacing: 1px;
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .intro {
@@ -34,6 +35,7 @@
       text-align: center;
       font-size: clamp(16px, 1.8vw, 21px);
       line-height: 1.45;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .alphabet-nav {
@@ -137,11 +139,13 @@
       font-size: 1.06rem;
       text-decoration: underline;
       font-weight: bold;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .entry-definition {
       margin: 0;
       line-height: 1.35;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .motifs {

--- a/magic.html
+++ b/magic.html
@@ -30,11 +30,13 @@
     .magic-heading h1 {
       margin: 0 0 10px;
       font-size: clamp(28px, 4vw, 40px);
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .magic-heading p {
       margin: 0;
       font-size: clamp(18px, 2vw, 24px);
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .tab-row {
@@ -84,6 +86,7 @@
       font-size: clamp(22px, 3vw, 30px);
       border-bottom: 1px solid #555;
       padding-bottom: 4px;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .alchemy-cards {
@@ -100,6 +103,7 @@
     .alchemy-card h3 {
       margin: 0 0 8px;
       font-size: 24px;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .alchemy-fields {
@@ -113,10 +117,12 @@
 
     .alchemy-fields dt {
       font-weight: bold;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .alchemy-fields dd {
       margin: 0;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .alchemy-help {

--- a/timeline.html
+++ b/timeline.html
@@ -30,12 +30,14 @@
     .timeline-heading h1 {
       margin: 0 0 8px;
       font-size: clamp(26px, 4vw, 40px);
+      text-shadow: 0 0 12px rgba(255, 255, 255, 0.98), 0 0 6px rgba(255, 255, 255, 0.96), 1px 1px 0 rgba(255, 255, 255, 0.92);
     }
 
     .timeline-heading p {
       margin: 0;
       font-size: clamp(18px, 2vw, 22px);
       line-height: 1.4;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .timeline {
@@ -99,6 +101,7 @@
       font-family: inherit;
       font-size: clamp(18px, 2vw, 24px);
       cursor: pointer;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .event-title[aria-expanded="true"] {
@@ -123,6 +126,7 @@
     .event-card h3 {
       margin: 0 0 6px;
       font-size: 28px;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .event-years,
@@ -130,10 +134,12 @@
     .event-note {
       margin: 0 0 8px;
       font-style: italic;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .event-summary {
       margin: 0 0 10px;
+      text-shadow: 0 0 10px rgba(255, 255, 255, 0.97), 0 0 4px rgba(255, 255, 255, 0.95);
     }
 
     .event-image {


### PR DESCRIPTION
### Motivation

- Improve readability and visual polish by adding subtle text-shadow/glow effects to headings and important text elements across several site pages.

### Description

- Added `text-shadow` rules to various selectors in `atlas.html`, `creatures.html`, `glossary.html`, `magic.html`, and `timeline.html` to apply a gentle glow to headings, intros, field labels, and card text without changing layout or behavior.

### Testing

- No automated tests were run for this presentational change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc4a09b848324b19658c9891eb01a)