### PR TITLE
Hide internal launch instruction from under-construction pages

### DIFF
--- a/under-construction.js
+++ b/under-construction.js
@@ -36,7 +36,6 @@
   sign.innerHTML = `
     <h1>UNDER CONSTRUCTION</h1>
     <p>${title} is currently being prepared.</p>
-    <p class="uc-note">Set <code>UNDER_CONSTRUCTION_MODE</code> to <code>false</code> in <code>under-construction.js</code> when you are ready to launch.</p>
   `;
 
   main.appendChild(sign);
@@ -69,12 +68,6 @@
         margin: 0;
         font-size: clamp(18px, 2.4vw, 28px);
         line-height: 1.35;
-      }
-
-      .uc-sign .uc-note {
-        margin-top: 16px;
-        font-size: clamp(14px, 1.7vw, 18px);
-        opacity: 0.9;
       }
     `;
     document.head.appendChild(style);


### PR DESCRIPTION
### Motivation
- Prevent internal editor guidance from being visible to site visitors by removing the public-facing launch instruction from the under-construction sign.

### Description
- Removed the instructional note from `under-construction.js` and deleted the now-unused `.uc-note` CSS block so the sign now only displays the heading and the "currently being prepared" message.

### Testing
- Confirmed the phrase was removed with `rg -n "Set <code>UNDER_CONSTRUCTION_MODE</code> to <code>false</code>" under-construction.js` (no matches), served the site with `python3 -m http.server 8000`, and captured `atlas.html` with Playwright to verify the instruction is no longer shown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accb253ab4832484ce420ef3ad1d78)