### PR TITLE
Add global site config and centralize under-construction mode

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -315,6 +315,7 @@
       regions: []
     });
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -693,3 +693,6 @@ document.getElementById("jumpToday").addEventListener("click", () => {
 
 render();
 </script>
+
+<script src="site-config.js"></script>
+<script src="under-construction.js"></script>

--- a/creatures.html
+++ b/creatures.html
@@ -183,6 +183,7 @@
       document.getElementById("creatures-page-intro").textContent = "Creature field guide data failed to load.";
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/fables.html
+++ b/fables.html
@@ -68,6 +68,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/field-thistles.html
+++ b/field-thistles.html
@@ -250,5 +250,7 @@
     fetch('header.html').then(r=>r.text()).then(html=>{ document.getElementById('site-header').innerHTML = html; });
     fetch('footer.html').then(r=>r.text()).then(html=>{ document.getElementById('site-footer').innerHTML = html; });
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/glossary.html
+++ b/glossary.html
@@ -321,6 +321,7 @@
       })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -62,5 +62,7 @@
     .then(res => res.text())
     .then(data => document.getElementById("footer").innerHTML = data);
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/magic.html
+++ b/magic.html
@@ -267,6 +267,7 @@
       document.getElementById("panel-alchemy").innerHTML = '<p class="magic-placeholder">Alchemy guide data failed to load.</p>';
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/old-friends.html
+++ b/old-friends.html
@@ -68,6 +68,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/parsklands.html
+++ b/parsklands.html
@@ -292,5 +292,7 @@
   }
 
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/site-config.js
+++ b/site-config.js
@@ -1,0 +1,29 @@
+// Global site switches.
+// Change true/false values here when you want to turn features on or off.
+window.SITE_CONFIG = {
+  // Master switch for under-construction mode across the whole site.
+  // false = always off everywhere.
+  // true = check each page switch below.
+  UNDER_CONSTRUCTION_MODE: true,
+
+  // Per-page under-construction switches.
+  // Set a page to true/false to override it individually.
+  // If a page is missing from this list, it follows UNDER_CONSTRUCTION_MODE.
+  UNDER_CONSTRUCTION_PAGES: {
+    "index.html": false,
+    "site-policies.html": false,
+    "field-thistles.html": false,
+    "parsklands.html": false,
+    "atlas.html": true,
+    "magic.html": true,
+    "creatures.html": true,
+    "timeline.html": true,
+    "glossary.html": true,
+    "words-of-parsk.html": true,
+    "fables.html": true,
+    "small-memories.html": true,
+    "old-friends.html": true,
+    "calendar.html": false,
+    "test.html": false
+  }
+};

--- a/site-policies.html
+++ b/site-policies.html
@@ -65,5 +65,7 @@
     .then(res => res.text())
     .then(data => document.getElementById("footer").innerHTML = data);
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/small-memories.html
+++ b/small-memories.html
@@ -68,6 +68,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/test.html
+++ b/test.html
@@ -106,5 +106,7 @@
       .then(res => res.text())
       .then(data => document.getElementById("footer").innerHTML = data);
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/timeline.html
+++ b/timeline.html
@@ -284,6 +284,7 @@
       document.getElementById("timeline-page-subtitle").textContent = "Timeline data failed to load.";
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/under-construction.js
+++ b/under-construction.js
@@ -1,33 +1,28 @@
 (() => {
-  // Flip this to false when you are ready to launch your page content.
-  const UNDER_CONSTRUCTION_MODE = true;
-
-  const pagesUnderConstruction = new Set([
-    "atlas.html",
-    "magic.html",
-    "creatures.html",
-    "timeline.html",
-    "glossary.html",
-    "words-of-parsk.html",
-    "fables.html",
-    "small-memories.html",
-    "old-friends.html"
-  ]);
-
+  const siteConfig = window.SITE_CONFIG || {};
   const currentPage = window.location.pathname.split("/").pop() || "index.html";
 
-  if (!UNDER_CONSTRUCTION_MODE || !pagesUnderConstruction.has(currentPage)) {
+  const globalToggle = siteConfig.UNDER_CONSTRUCTION_MODE ?? false;
+  const pageToggles = siteConfig.UNDER_CONSTRUCTION_PAGES || {};
+  const pageToggle = pageToggles[currentPage];
+
+  const isUnderConstruction = typeof pageToggle === "boolean" ? pageToggle : globalToggle;
+
+  if (!isUnderConstruction) {
     return;
   }
 
-  const main = document.querySelector("main");
-  if (!main) {
+  const container = document.querySelector("main") || document.body;
+  if (!container) {
     return;
   }
 
   const title = document.title.split("|")[0].trim() || "This page";
 
-  for (const child of Array.from(main.children)) {
+  for (const child of Array.from(container.children)) {
+    if (child.tagName === "SCRIPT" || child.tagName === "STYLE") {
+      continue;
+    }
     child.hidden = true;
   }
 
@@ -38,7 +33,7 @@
     <p>${title} is currently being prepared.</p>
   `;
 
-  main.appendChild(sign);
+  container.appendChild(sign);
 
   if (!document.getElementById("uc-sign-style")) {
     const style = document.createElement("style");

--- a/words-of-parsk.html
+++ b/words-of-parsk.html
@@ -459,5 +459,7 @@
       .then(html => { document.getElementById('site-footer').innerHTML = html; })
       .catch(err => console.error('Footer failed to load.', err));
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Introduce a single, editable configuration for toggling site-wide and per-page "under construction" behavior via `window.SITE_CONFIG` instead of hardcoded page lists. 
- Make the under-construction overlay logic reusable across pages and easier to manage from one file (`site-config.js`).
- Ensure pages can opt in/out of the overlay dynamically and make the overlay insertion more robust across different document structures.

### Description
- Add a new `site-config.js` file that exposes `window.SITE_CONFIG` with `UNDER_CONSTRUCTION_MODE` and `UNDER_CONSTRUCTION_PAGES` mapping for per-page overrides. 
- Rewrite `under-construction.js` to read `window.SITE_CONFIG`, compute the active toggle for the current page, target `main` or `body` as the container, skip `SCRIPT`/`STYLE` children when hiding existing content, and inject a standardized `.uc-sign` overlay. 
- Include `site-config.js` (and in most pages also `under-construction.js`) in a number of HTML pages by adding `<script src=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addc6ab1448324a788b15c491c0f5e)