### PR TITLE
Add configurable under‑construction system with per‑page and site config

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Atlas | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -315,6 +320,7 @@
       regions: []
     });
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -1,3 +1,7 @@
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = false;
+  </script>
 <!-- calendar.html (layout fix: scroll 12 months horizontally + top overview blurb) -->
 <div class="owcal" id="owcal">
   <!-- TOP BAR: TODAY / SELECTED DAY -->
@@ -693,3 +697,6 @@ document.getElementById("jumpToday").addEventListener("click", () => {
 
 render();
 </script>
+
+<script src="site-config.js"></script>
+<script src="under-construction.js"></script>

--- a/creatures.html
+++ b/creatures.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Creatures | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -183,6 +188,7 @@
       document.getElementById("creatures-page-intro").textContent = "Creature field guide data failed to load.";
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/fables.html
+++ b/fables.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Voices and Fables | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -68,6 +73,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/field-thistles.html
+++ b/field-thistles.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Field Thistles</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = false;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <style>
     :root {
       --overlay-bg: rgba(0,0,0,.75);
@@ -250,5 +255,7 @@
     fetch('header.html').then(r=>r.text()).then(html=>{ document.getElementById('site-header').innerHTML = html; });
     fetch('footer.html').then(r=>r.text()).then(html=>{ document.getElementById('site-footer').innerHTML = html; });
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/glossary.html
+++ b/glossary.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Glossary | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -321,6 +326,7 @@
       })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Art by Wren Willow</title>
 
-  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = false;
+  </script>
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="style.css">
 </head>
@@ -62,5 +67,7 @@
     .then(res => res.text())
     .then(data => document.getElementById("footer").innerHTML = data);
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/magic.html
+++ b/magic.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Magic | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -267,6 +272,7 @@
       document.getElementById("panel-alchemy").innerHTML = '<p class="magic-placeholder">Alchemy guide data failed to load.</p>';
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/old-friends.html
+++ b/old-friends.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Old Friends | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -68,6 +73,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/parsklands.html
+++ b/parsklands.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Door to the Parsklands</title>
 
+
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = false;
+  </script>
 <link rel="stylesheet" href="style.css" />
 <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
 
@@ -292,5 +297,7 @@
   }
 
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/site-config.js
+++ b/site-config.js
@@ -1,0 +1,28 @@
+// Global site switches.
+// You can mostly use each page's own toggle near the top of that page file.
+// This file is optional fallback control.
+window.SITE_CONFIG = {
+  // Master fallback switch.
+  UNDER_CONSTRUCTION_MODE: false,
+
+  // Optional fallback page switches.
+  // If a page has window.PAGE_UNDER_CONSTRUCTION in its HTML,
+  // that inline value takes priority.
+  UNDER_CONSTRUCTION_PAGES: {
+    "index.html": false,
+    "site-policies.html": false,
+    "field-thistles.html": false,
+    "parsklands.html": false,
+    "atlas.html": true,
+    "magic.html": true,
+    "creatures.html": true,
+    "timeline.html": true,
+    "glossary.html": true,
+    "words-of-parsk.html": true,
+    "fables.html": true,
+    "small-memories.html": true,
+    "old-friends.html": true,
+    "calendar.html": false,
+    "test.html": false
+  }
+};

--- a/site-policies.html
+++ b/site-policies.html
@@ -5,7 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Art by Wren Willow</title>
 
-  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = false;
+  </script>
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="style.css">
 </head>
@@ -65,5 +70,7 @@
     .then(res => res.text())
     .then(data => document.getElementById("footer").innerHTML = data);
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/small-memories.html
+++ b/small-memories.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Small Memories | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -68,6 +73,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/test.html
+++ b/test.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Art by Wren Willow</title>
-  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = false;
+  </script>
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     .gallery {
@@ -106,5 +111,7 @@
       .then(res => res.text())
       .then(data => document.getElementById("footer").innerHTML = data);
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/timeline.html
+++ b/timeline.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Timeline | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -284,6 +289,7 @@
       document.getElementById("timeline-page-subtitle").textContent = "Timeline data failed to load.";
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/under-construction.js
+++ b/under-construction.js
@@ -1,33 +1,38 @@
 (() => {
-  // Flip this to false when you are ready to launch your page content.
-  const UNDER_CONSTRUCTION_MODE = true;
-
-  const pagesUnderConstruction = new Set([
-    "atlas.html",
-    "magic.html",
-    "creatures.html",
-    "timeline.html",
-    "glossary.html",
-    "words-of-parsk.html",
-    "fables.html",
-    "small-memories.html",
-    "old-friends.html"
-  ]);
-
+  const siteConfig = window.SITE_CONFIG || {};
   const currentPage = window.location.pathname.split("/").pop() || "index.html";
 
-  if (!UNDER_CONSTRUCTION_MODE || !pagesUnderConstruction.has(currentPage)) {
+  const globalToggle = siteConfig.UNDER_CONSTRUCTION_MODE ?? false;
+  const pageToggles = siteConfig.UNDER_CONSTRUCTION_PAGES || {};
+  const configPageToggle = pageToggles[currentPage];
+  const inlinePageToggle = window.PAGE_UNDER_CONSTRUCTION;
+
+  // Priority:
+  // 1) per-page inline toggle in each HTML file
+  // 2) optional per-page toggle in site-config.js
+  // 3) global site-config.js toggle
+  const isUnderConstruction =
+    typeof inlinePageToggle === "boolean"
+      ? inlinePageToggle
+      : typeof configPageToggle === "boolean"
+        ? configPageToggle
+        : globalToggle;
+
+  if (!isUnderConstruction) {
     return;
   }
 
-  const main = document.querySelector("main");
-  if (!main) {
+  const container = document.querySelector("main") || document.body;
+  if (!container) {
     return;
   }
 
   const title = document.title.split("|")[0].trim() || "This page";
 
-  for (const child of Array.from(main.children)) {
+  for (const child of Array.from(container.children)) {
+    if (child.tagName === "SCRIPT" || child.tagName === "STYLE") {
+      continue;
+    }
     child.hidden = true;
   }
 
@@ -38,7 +43,7 @@
     <p>${title} is currently being prepared.</p>
   `;
 
-  main.appendChild(sign);
+  container.appendChild(sign);
 
   if (!document.getElementById("uc-sign-style")) {
     const style = document.createElement("style");

--- a/words-of-parsk.html
+++ b/words-of-parsk.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Words of Parsk | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+  
+  <!-- Page under-construction toggle: set to true or false -->
+  <script>
+    window.PAGE_UNDER_CONSTRUCTION = true;
+  </script>
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     :root {
@@ -459,5 +464,7 @@
       .then(html => { document.getElementById('site-footer').innerHTML = html; })
       .catch(err => console.error('Footer failed to load.', err));
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Provide a controllable "under construction" feature across the site so pages can be toggled on/off without editing the core toggle code.
- Allow per-page inline overrides while offering a central fallback configuration for convenience and bulk changes.

### Description

- Introduce a new configuration file `site-config.js` that exposes `UNDER_CONSTRUCTION_MODE` and `UNDER_CONSTRUCTION_PAGES` as site-wide fallbacks.
- Rewrite `under-construction.js` to respect priority: inline `window.PAGE_UNDER_CONSTRUCTION` → `site-config.js` per-page flag → global `UNDER_CONSTRUCTION_MODE`, and to hide a page's content more robustly (targets `main` or `body`, skips `SCRIPT`/`STYLE` when hiding, and appends an unobtrusive construction sign with styling).
- Add inline per-page toggles (`window.PAGE_UNDER_CONSTRUCTION = true|false`) to multiple HTML files and include `site-config.js` and `under-construction.js` near the end of pages (examples: `index.html`, `parsklands.html`, `atlas.html`, `creatures.html`, `glossary.html`, `timeline.html`, `field-thistles.html`, and others).
- Minor HTML cleanups where necessary to integrate the new scripts and fallbacks without changing page content beyond the construction handling.

### Testing

- No automated tests are configured or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addc6ab1448324a788b15c491c0f5e)