### PR TITLE
Centralize under-construction toggles and wire site config into pages

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Atlas | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -315,6 +315,7 @@
       regions: []
     });
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -1,3 +1,4 @@
+
 <!-- calendar.html (layout fix: scroll 12 months horizontally + top overview blurb) -->
 <div class="owcal" id="owcal">
   <!-- TOP BAR: TODAY / SELECTED DAY -->
@@ -693,3 +694,6 @@ document.getElementById("jumpToday").addEventListener("click", () => {
 
 render();
 </script>
+
+<script src="site-config.js"></script>
+<script src="under-construction.js"></script>

--- a/creatures.html
+++ b/creatures.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Creatures | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -183,6 +183,7 @@
       document.getElementById("creatures-page-intro").textContent = "Creature field guide data failed to load.";
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/fables.html
+++ b/fables.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Voices and Fables | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -68,6 +68,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/field-thistles.html
+++ b/field-thistles.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Field Thistles</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <style>
     :root {
       --overlay-bg: rgba(0,0,0,.75);
@@ -250,5 +250,7 @@
     fetch('header.html').then(r=>r.text()).then(html=>{ document.getElementById('site-header').innerHTML = html; });
     fetch('footer.html').then(r=>r.text()).then(html=>{ document.getElementById('site-footer').innerHTML = html; });
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/glossary.html
+++ b/glossary.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Glossary | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -321,6 +321,7 @@
       })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Art by Wren Willow</title>
-
-  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="style.css">
 </head>
@@ -62,5 +61,7 @@
     .then(res => res.text())
     .then(data => document.getElementById("footer").innerHTML = data);
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/magic.html
+++ b/magic.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Magic | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -267,6 +267,7 @@
       document.getElementById("panel-alchemy").innerHTML = '<p class="magic-placeholder">Alchemy guide data failed to load.</p>';
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/old-friends.html
+++ b/old-friends.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Old Friends | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -68,6 +68,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/parsklands.html
+++ b/parsklands.html
@@ -4,7 +4,6 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Door to the Parsklands</title>
-
 <link rel="stylesheet" href="style.css" />
 <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
 
@@ -292,5 +291,7 @@
   }
 
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/site-config.js
+++ b/site-config.js
@@ -1,0 +1,25 @@
+// Global site switches for under-construction mode.
+// Edit this file to control all pages.
+window.SITE_CONFIG = {
+  // Global fallback when a page is not listed below.
+  UNDER_CONSTRUCTION_MODE: false,
+
+  // Per-page switches (single place to toggle individual pages).
+  UNDER_CONSTRUCTION_PAGES: {
+    "index.html": false,
+    "site-policies.html": false,
+    "field-thistles.html": false,
+    "parsklands.html": false,
+    "atlas.html": true,
+    "magic.html": true,
+    "creatures.html": true,
+    "timeline.html": true,
+    "glossary.html": true,
+    "words-of-parsk.html": true,
+    "fables.html": true,
+    "small-memories.html": true,
+    "old-friends.html": true,
+    "calendar.html": false,
+    "test.html": false
+  }
+};

--- a/site-policies.html
+++ b/site-policies.html
@@ -4,8 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Art by Wren Willow</title>
-
-  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="style.css">
 </head>
@@ -65,5 +64,7 @@
     .then(res => res.text())
     .then(data => document.getElementById("footer").innerHTML = data);
 </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/small-memories.html
+++ b/small-memories.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Small Memories | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -68,6 +68,7 @@
       .then(html => { document.getElementById("footer").innerHTML = html; })
       .catch(err => console.error("Footer failed to load.", err));
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/test.html
+++ b/test.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Art by Wren Willow</title>
-  <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>
     .gallery {
@@ -106,5 +106,7 @@
       .then(res => res.text())
       .then(data => document.getElementById("footer").innerHTML = data);
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>

--- a/timeline.html
+++ b/timeline.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Timeline | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     main {
@@ -284,6 +284,7 @@
       document.getElementById("timeline-page-subtitle").textContent = "Timeline data failed to load.";
     }
   </script>
+  <script src="site-config.js"></script>
   <script src="under-construction.js"></script>
 </body>
 </html>

--- a/under-construction.js
+++ b/under-construction.js
@@ -1,34 +1,53 @@
 (() => {
-  // Flip this to false when you are ready to launch your page content.
-  const UNDER_CONSTRUCTION_MODE = true;
-
-  const pagesUnderConstruction = new Set([
-    "atlas.html",
-    "magic.html",
-    "creatures.html",
-    "timeline.html",
-    "glossary.html",
-    "words-of-parsk.html",
-    "fables.html",
-    "small-memories.html",
-    "old-friends.html"
-  ]);
-
+  const siteConfig = window.SITE_CONFIG || {};
   const currentPage = window.location.pathname.split("/").pop() || "index.html";
 
-  if (!UNDER_CONSTRUCTION_MODE || !pagesUnderConstruction.has(currentPage)) {
+  const globalToggle = siteConfig.UNDER_CONSTRUCTION_MODE ?? false;
+  const pageToggles = siteConfig.UNDER_CONSTRUCTION_PAGES || {};
+  const pageToggle = pageToggles[currentPage];
+
+  // site-config.js is the single source of truth:
+  // 1) per-page toggle in UNDER_CONSTRUCTION_PAGES
+  // 2) global UNDER_CONSTRUCTION_MODE fallback
+  const isUnderConstruction =
+    typeof pageToggle === "boolean" ? pageToggle : globalToggle;
+
+  if (!isUnderConstruction) {
     return;
   }
 
-  const main = document.querySelector("main");
-  if (!main) {
+  const body = document.body;
+  if (!body) {
     return;
   }
 
   const title = document.title.split("|")[0].trim() || "This page";
 
-  for (const child of Array.from(main.children)) {
+  const headerSlot = document.getElementById("header") || document.querySelector("header");
+  const footerSlot = document.getElementById("footer") || document.querySelector("footer");
+
+  for (const child of Array.from(body.children)) {
+    if (child.tagName === "SCRIPT" || child.tagName === "STYLE") {
+      continue;
+    }
+
+    if (child === headerSlot || child === footerSlot) {
+      continue;
+    }
+
     child.hidden = true;
+  }
+
+  let signHost = document.getElementById("uc-sign-host");
+  if (!signHost) {
+    signHost = document.createElement("div");
+    signHost.id = "uc-sign-host";
+
+    if (footerSlot && footerSlot.parentElement === body) {
+      body.insertBefore(signHost, footerSlot);
+    } else {
+      body.appendChild(signHost);
+    }
   }
 
   const sign = document.createElement("section");
@@ -38,7 +57,7 @@
     <p>${title} is currently being prepared.</p>
   `;
 
-  main.appendChild(sign);
+  signHost.replaceChildren(sign);
 
   if (!document.getElementById("uc-sign-style")) {
     const style = document.createElement("style");

--- a/words-of-parsk.html
+++ b/words-of-parsk.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Words of Parsk | Door to the Parsklands</title>
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Baskervville&display=swap" rel="stylesheet" />
   <style>
     :root {
@@ -459,5 +459,7 @@
       .then(html => { document.getElementById('site-footer').innerHTML = html; })
       .catch(err => console.error('Footer failed to load.', err));
   </script>
+  <script src="site-config.js"></script>
+  <script src="under-construction.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Provide a single source of truth to control which pages show an "under construction" placeholder without editing many files. 
- Make the existing `under-construction.js` respect per-page and global toggles configured in one place. 

### Description

- Add `site-config.js` providing `window.SITE_CONFIG` with `UNDER_CONSTRUCTION_MODE` and `UNDER_CONSTRUCTION_PAGES` to centrally manage under-construction state. 
- Update `under-construction.js` to read `window.SITE_CONFIG`, compute per-page fallback logic, and change DOM handling to hide non-header/footer content and inject a reusable under-construction sign container. 
- Inject `<script src="site-config.js"></script>` into the site's HTML pages so `under-construction.js` can consult the central config before acting. 
- Small markup/whitespace normalization in a number of HTML files to keep script and link tags consistent. 

### Testing

- Performed local headless smoke checks by loading representative pages and verifying the under-construction sign is shown or suppressed according to `site-config.js` and page toggles, and these checks passed. 
- Confirmed `under-construction.js` does not run when a page is toggled off and that header/footer includes are preserved, and these checks passed. 
- No automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addc6ab1448324a788b15c491c0f5e)