### PR TITLE
Remove thin separator line from footer starfield

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,4 +1,4 @@
-<footer style="text-align: center; font-size: 0.9em; padding: 20px; background-color: #000; color: white; border-top: 2px solid #333; margin-top: 40px;">
+<footer style="text-align: center; font-size: 0.9em; padding: 20px; background-color: #000; color: white; margin-top: 40px;">
   <div style="background-color: rgba(255, 255, 255, 0.85); display: inline-block; padding: 20px 30px; border: 4px groove #222; box-shadow: 4px 4px 8px #555;">
     <span style="display: block; margin-bottom: 10px; color: black;">
       © Copyright 2025-2026. All rights reserved. – Website best viewed on desktop.


### PR DESCRIPTION
### Motivation
- Remove the thin horizontal separator that appeared across the starry footer background so the footer artwork is uninterrupted.

### Description
- Deleted the inline `border-top: 2px solid #333;` style from `footer.html` and left all other footer markup and styles unchanged.

### Testing
- Reviewed the file diff for `footer.html`, served the site locally with a simple HTTP server, and captured a Playwright screenshot of the footer to confirm the thin line is gone (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1445ae7883248624dfc31cfea0fe)