### PR TITLE
Limit under-construction navigation detection to explicit header/footer IDs

### DIFF
--- a/under-construction.js
+++ b/under-construction.js
@@ -45,11 +45,11 @@
       return true;
     }
 
-    if (el.matches("header, nav, #header, #footer, #site-header, #site-footer")) {
+    if (el.matches("#header, #footer, #site-header, #site-footer")) {
       return true;
     }
 
-    return Boolean(el.querySelector("header, nav, #header, #footer, #site-header, #site-footer"));
+    return Boolean(el.querySelector("#header, #footer, #site-header, #site-footer"));
   };
 
   for (const child of Array.from(body.children)) {


### PR DESCRIPTION
### Motivation
- The Atlas page (and similar pages) was leaving media between the header and footer visible when under-construction mode was enabled, so the goal is to ensure that only explicit header/footer containers are preserved and all other body content is hidden when the site config toggles a page to under-construction.

### Description
- Changed `isNavigationContainer` in `under-construction.js` to stop recognizing semantic `header`/`nav` elements as navigation containers.
- Updated both the `el.matches(...)` and `el.querySelector(...)` checks to only look for explicit ID selectors `#header`, `#footer`, `#site-header`, and `#site-footer`.
- The script still preserves detected header/footer slots and inserts the under-construction sign host, while hiding all other non-script/style body children when under-construction is active.

### Testing
- Ran `node --check under-construction.js` with no syntax errors reported.
- Served the site with `python3 -m http.server 4173` and executed a Playwright script that loaded `http://127.0.0.1:4173/atlas.html` and captured a screenshot; the page loaded and the screenshot artifact was produced successfully.
- The modified `under-construction.js` executed in-browser during the automated load and exhibited the expected behavior (header/footer preserved, other body media hidden).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0613d853c83249e8226f983ecc701)